### PR TITLE
playing with write()

### DIFF
--- a/circuitpython_nrf24l01/rf24_lite.py
+++ b/circuitpython_nrf24l01/rf24_lite.py
@@ -302,6 +302,7 @@ class RF24:
 
     def update(self):
         self._reg_write(0xFF)
+        return True
 
     def resend(self, send_only=False):
         result = False
@@ -326,6 +327,8 @@ class RF24:
         if not buf or len(buf) > 32:
             raise ValueError("buffer length must be in range [1, 32]")
         self.clear_status_flags()
+        if self.tx_full:
+            return False
         config = self._reg_read(0)
         if config & 3 != 2:
             self._reg_write(0, (config & 0x7C) | 2)
@@ -339,6 +342,7 @@ class RF24:
         self._reg_write_bytes(0xA0 | (ask_no_ack << 4), buf)
         if not write_only:
             self.ce_pin.value = 1
+        return True
 
     def flush_rx(self):
         self._reg_write(0xE2)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -51,7 +51,11 @@ Library-Specific Features
 Stream Example
 ---------------
 
-This is a test to show how to use the :py:func:`~circuitpython_nrf24l01.rf24.RF24.send()` to transmit multiple payloads with 1 function call.
+This is a test to show how to stream data. The ``master()`` uses the `send()` to
+transmit multiple payloads with 1 function call. However ``master()`` only uses 1
+level of the nRF24L01's TX FIFO. An alternate function, called ``master_fifo()``
+uses all 3 levels of the nRF24L01's TX FIFO to stream data, but it uses the
+`write()` function to do so.
 
 .. literalinclude:: ../examples/nrf24l01_stream_test.py
     :caption: examples/nrf24l01_stream_test.py

--- a/examples/nrf24l01_2arduino_handling_data.py
+++ b/examples/nrf24l01_2arduino_handling_data.py
@@ -94,7 +94,7 @@ def slave(count=3):
     myData.time = time.monotonic() * 1000  # in milliseconds
     while count and (time.monotonic() * 1000 - myData.time) < 6000:
         nrf.listen = True  # put radio into RX mode and power up
-        if nrf.any():
+        if nrf.update() and nrf.pipe is not None:
             # retreive the received packet's payload
             buffer = nrf.recv()  # clears flags & empties RX FIFO
             # increment floating value as part of the "HandlingData" test

--- a/examples/nrf24l01_ack_payload_test.py
+++ b/examples/nrf24l01_ack_payload_test.py
@@ -85,7 +85,7 @@ def slave(count=5):
 
     start = time.monotonic()  # start timer
     while count and (time.monotonic() - start) < 6:  # use 6 second timeout
-        if nrf.any():
+        if nrf.update() and nrf.pipe is not None:
             count -= 1
             # retreive the received packet's payload
             rx = nrf.recv()  # clears flags & empties RX FIFO

--- a/examples/nrf24l01_stream_test.py
+++ b/examples/nrf24l01_stream_test.py
@@ -28,14 +28,11 @@ nrf = RF24(spi, csn, ce)
 nrf.pa_level = -12
 
 
-def master(count=1):  # count = 5 will transmit the list 5 times
-    """Transmits a massive buffer of payloads"""
-    # lets create a `list` of payloads to be streamed to
-    # the nRF24L01 running slave()
+def make_buffers(size=32):
+    """private function to construct a large list of payloads"""
     buffers = []
-    # we'll use SIZE for the number of payloads in the list and the
+    # we'll use `size` for the number of payloads in the list and the
     # payloads' length
-    size = 32
     for i in range(size):
         # prefix payload with a sequential letter to indicate which
         # payloads were lost (if any)
@@ -46,44 +43,104 @@ def master(count=1):  # count = 5 will transmit the list 5 times
             buff += bytes([char + 48])
         buffers.append(buff)
         del buff
+    return buffers
 
-    # set address of RX node into a TX pipe
-    nrf.open_tx_pipe(address)
-    # ensures the nRF24L01 is in TX mode
-    nrf.listen = False
 
-    successful = 0
+def master(count=1, size=32):  # count = 5 will transmit the list 5 times
+    """Transmits multiple payloads using `RF24.send()` and `RF24.resend()`."""
+    buffers = make_buffers(size)  # make a list of payloads
+    nrf.open_tx_pipe(address)  # set address of RX node into a TX pipe
+    nrf.listen = False  # ensures the nRF24L01 is in TX mode
+    successful = 0  # keep track of success rate
     for _ in range(count):
-        now = time.monotonic() * 1000  # start timer
-        result = nrf.send(buffers, force_retry=2)
-        print("Transmission took", time.monotonic() * 1000 - now, "ms")
-        for r in result:
+        start_timer = time.monotonic() * 1000  # start timer
+        # NOTE force_retry=2 internally invokes `RF24.resend()` 2 times at
+        # most for payloads that fail to transmit.
+        result = nrf.send(buffers, force_retry=2)  # result is a list
+        end_timer = time.monotonic() * 1000  # end timer
+        print("Transmission took", end_timer - start_timer, "ms")
+        for r in result:  # tally the resulting success rate
             successful += 1 if r else 0
     print(
         "successfully sent {}% ({}/{})".format(
-            successful / (size* count) * 100, successful, size * count
+            successful / (size * count) * 100,
+            successful,
+            size * count
         )
     )
 
 
+def master_fifo(count=1, size=32):
+    """Similar to the `master()` above except this function uses the full
+    TX FIFO and `RF24.write()` instead of `RF24.send()`"""
+    if size < 6:
+        print("setting size to 6;", size, "is not allowed for this test.")
+        size = 6
+    buf = make_buffers(size)  # make a list of payloads
+    nrf.open_tx_pipe(address)  # set address of RX node into a TX pipe
+    nrf.listen = False  # ensures the nRF24L01 is in TX mode
+    for c in range(count):  # transmit the same payloads this many times
+        nrf.flush_tx()  # clear the TX FIFO so we can use all 3 levels
+        # NOTE the write_only parameter does not initiate sending
+        buf_iter = 0  # iterator of payloads for the while loop
+        failures = 0  # keep track of manual retries
+        start_timer = time.monotonic() * 1000  # start timer
+        while buf_iter < size:  # cycle through all the payloads
+            while buf_iter < size and nrf.write(buf[buf_iter], write_only=1):
+                # NOTE write() returns False if TX FIFO is already full
+                buf_iter += 1  # increment iterator of payloads
+            ce.value = True  # start tranmission (after 10 microseconds)
+            while not nrf.fifo(True, True):  # updates irq_df flag
+                if nrf.irq_df:
+                    # reception failed; we need to reset the irq_rf flag
+                    ce.value = False  # fall back to Standby-I mode
+                    failures += 1  # increment manual retries
+                    if failures > 99 and buf_iter < 7 and c < 2:
+                        # we need to prevent an infinite loop
+                        print(
+                            "Make sure slave() node is listening."
+                            " Quiting master_fifo()"
+                        )
+                        buf_iter = size + 1  # be sure to exit the while loop
+                        nrf.flush_tx()  # discard all payloads in TX FIFO
+                        break
+                    nrf.clear_status_flags()  # clear the irq_df flag
+                    ce.value = True  # start re-transmitting
+            ce.value = False
+        end_timer = time.monotonic() * 1000  # end timer
+        print(
+            "Transmission took {} ms with {} failures detected.".format(
+                end_timer - start_timer,
+                failures
+            ),
+            end=" " if failures < 100 else "\n"
+        )
+        if 1 <= failures < 100:
+            print(
+                "\n\nHINT: Try playing with the 'ard' and 'arc' attributes to"
+                " reduce the number of\nfailures detected. Tests were better"
+                " with these attributes at higher values, but\nnotice the "
+                "transmission time differences."
+            )
+        elif not failures:
+            print("You Win!")
+
+
 def slave(timeout=5):
-    """Stops listening after timeout with no response"""
+    """Stops listening after a `timeout` with no response"""
     # set address of TX node into an RX pipe. NOTE you MUST specify
     # which pipe number to use for RX, we'll be using pipe 0
-    # pipe number options range [0,5]
-    # the pipe numbers used during a transition don't have to match
-    nrf.open_rx_pipe(0, address)
+    nrf.open_rx_pipe(0, address)  # pipe number options range [0,5]
     nrf.listen = True  # put radio into RX mode and power up
-
-    count = 0
-    now = time.monotonic()  # start timer
-    while time.monotonic() < now + timeout:
-        if nrf.any():
+    count = 0  # keep track of the number of received payloads
+    start_timer = time.monotonic()  # start timer
+    while time.monotonic() < start_timer + timeout:
+        if nrf.update() and nrf.pipe is not None:
             count += 1
             # retreive the received packet's payload
             rx = nrf.recv()  # clears flags & empties RX FIFO
-            print("Received: {} - {}".format(repr(rx), count))
-            now = time.monotonic()
+            print("Received: {} - {}".format(count, rx))
+            start_timer = time.monotonic()  # reset timer on every RX payload
 
     # recommended behavior is to keep in TX mode while idle
     nrf.listen = False  # put the nRF24L01 is in TX mode
@@ -93,5 +150,6 @@ print(
     """\
     nRF24L01 Stream test\n\
     Run slave() on receiver\n\
-    Run master() on transmitter"""
+    Run master() on transmitter to use 1 level of the TX FIFO\n\
+    Run master_fifo() on transmitter to use all 3 levels of the TX FIFO."""
 )


### PR DESCRIPTION
- `update()` now always returns True
    - this allows for calling the `update()` function in a conditional statement.
        e.g. `if nrf.update() and nrf.pipe is not None:` (which is a bit faster than using `if nrf.any():` as the examples used prior to this change)
- `write()` return a boolean describing if the payload was written to the TX FIFO
- new `master_fifo()` function in the stream example to compare (& play) with original `master()` function.
    - `master_fifo()` uses the `write()` function to utilize all 3 levels of the TX FIFO. This function can provide some additional incite as to how many failed transmissions get retried when using `send(buf, force_retry=2)` in the original `master()` function.
    - `master()` still uses the `send()` function, but only manages 1 level of the TX FIFO (as it always has).