### PR TITLE
corrected is_plus_variant check when setting data_rate

### DIFF
--- a/circuitpython_nrf24l01/rf24.py
+++ b/circuitpython_nrf24l01/rf24.py
@@ -690,7 +690,7 @@ class RF24:
     def data_rate(self, speed):
         if not speed in (1, 2, 250):
             raise ValueError("data_rate must be 1 (Mbps), 2 (Mbps), or 250 (kbps)")
-        if self.is_plus_variant and speed == 250:
+        if not self.is_plus_variant and speed == 250:
             raise NotImplementedError(
                 "250 kbps data rate is not available for the non-plus "
                 "variants of the nRF24L01 transceivers."


### PR DESCRIPTION
fix faulty logic in `if self.is_plus_variant` statement when setting RF data rate to 250 kbps